### PR TITLE
Click stick fix

### DIFF
--- a/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.cpp
+++ b/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.cpp
@@ -961,7 +961,6 @@ IOReturn VoodooI2CSynapticsDevice::setPowerState(unsigned long powerState, IOSer
         IOLog("%s::Going to Sleep!\n", getName());
     } else {
         if (!awake){
-            rmi_populate();
             
             awake = true;
             IOLog("%s::Woke up from Sleep!\n", getName());


### PR DESCRIPTION
Fixes the issue of getting stuck in a click/drag/highlight mode after waking from sleep by removing  "rmi_populate();" from the wake sequence